### PR TITLE
Update gh-pages-deploy.yml

### DIFF
--- a/generator/templates/_github/workflows/gh-pages-deploy.yml
+++ b/generator/templates/_github/workflows/gh-pages-deploy.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Node.js for use with actions
-        uses: actions/setup-node@v1.4.4
+        uses: actions/setup-node@v2
         with:
-          version:  12.x
+          node-version:  12.x
       - name: Checkout branch
         uses: actions/checkout@v2
 


### PR DESCRIPTION
- Upgrade setup-node
- `version` is deprecated, use `node-version` instead